### PR TITLE
Support Gov Cloud.

### DIFF
--- a/api_integration.tf
+++ b/api_integration.tf
@@ -3,7 +3,7 @@ resource "snowflake_api_integration" "geff_api_integration" {
 
   name                 = "${upper(replace(var.prefix, "-", "_"))}_API_INTEGRATION"
   enabled              = true
-  api_provider         = "aws_api_gateway"
+  api_provider         = length(regexall(".*gov.*", local.aws_region)) > 0 ? "AWS_GOV_API_GATEWAY" : "AWS_API_GATEWAY"
   api_allowed_prefixes = [local.inferred_api_gw_invoke_url]
   api_aws_role_arn     = "arn:${var.arn_format}:iam::${local.account_id}:role/${local.api_gw_caller_role_name}"
 }


### PR DESCRIPTION
Support Gov Cloud.

AWS API Gateway Provider for Gov Cloud changes to `AWS_GOV_API_GATEWAY`.