### PR TITLE
Add support for sovereign cloud ARN format.

### DIFF
--- a/api_gateway.tf
+++ b/api_gateway.tf
@@ -22,7 +22,7 @@ resource "aws_api_gateway_rest_api_policy" "ef_to_lambda" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = "arn:${var.arn_format}:sts::${local.account_id}:assumed-role/${local.api_gw_caller_role_name}/snowflake"
+          AWS = "arn:${local.aws_partition}:sts::${local.account_id}:assumed-role/${local.api_gw_caller_role_name}/snowflake"
         }
         Action   = "execute-api:Invoke"
         Resource = "${aws_api_gateway_rest_api.ef_to_lambda.execution_arn}/*/*/*"

--- a/api_integration.tf
+++ b/api_integration.tf
@@ -5,7 +5,7 @@ resource "snowflake_api_integration" "geff_api_integration" {
   enabled              = true
   api_provider         = length(regexall(".*gov.*", local.aws_region)) > 0 ? "aws_gov_api_gateway" : "aws_api_gateway"
   api_allowed_prefixes = [local.inferred_api_gw_invoke_url]
-  api_aws_role_arn     = "arn:${var.arn_format}:iam::${local.account_id}:role/${local.api_gw_caller_role_name}"
+  api_aws_role_arn     = "arn:${local.aws_partition}:iam::${local.account_id}:role/${local.api_gw_caller_role_name}"
 }
 
 resource "snowflake_integration_grant" "geff_api_integration_grant" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,6 @@ module "geff" {
   env    = var.env
 
   # AWS
-  arn_format                      = var.arn_format
   aws_cloudwatch_metric_namespace = var.aws_cloudwatch_metric_namespace
   aws_region                      = var.aws_region
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,6 +27,7 @@ module "geff" {
   providers = {
     snowflake.api_integration_role     = snowflake.api_integration_role
     snowflake.storage_integration_role = snowflake.storage_integration_role
+    snowsql.storage_integration_role   = snowsql.storage_integration_role
     aws                                = aws
   }
 }

--- a/examples/complete/snowsql_provider.tf
+++ b/examples/complete/snowsql_provider.tf
@@ -1,6 +1,7 @@
 provider "snowsql" {
-  alias = "security_storage_integration_role"
+  alias = "storage_integration_role"
 
-  account = var.snowflake_account
-  role    = var.snowflake_storage_integration_owner_role
+  account  = var.snowflake_account
+  role     = var.snowflake_storage_integration_owner_role
+  username = "example_user"
 }

--- a/examples/complete/snowsql_provider.tf
+++ b/examples/complete/snowsql_provider.tf
@@ -1,0 +1,6 @@
+provider "snowsql" {
+  alias = "security_storage_integration_role"
+
+  account = var.snowflake_account
+  role    = var.snowflake_storage_integration_owner_role
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.4.6"
+  required_version = ">= 1.4.6"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,12 +4,21 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.38.0"
+      version = "~> 5.72.0"
     }
 
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.64.0"
+      version = "~> 0.73.0"
+    }
+
+    snowsql = {
+      source  = "aidanmelen/snowsql"
+      version = ">= 1.3.3"
+
+      configuration_aliases = [
+        snowsql.storage_integration_role,
+      ]
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "geff_api_gateway_assume_role" {
 
 resource "aws_iam_role_policy_attachment" "gateway_logger_policy_attachment" {
   role       = aws_iam_role.geff_api_gateway_assume_role.id
-  policy_arn = "arn:${var.arn_format}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+  policy_arn = "arn:${local.aws_partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
 
 resource "aws_api_gateway_account" "api_gateway" {
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "geff_lambda_policy_doc" {
     sid    = "WriteCloudWatchLogs"
     effect = "Allow"
     resources = [
-      "arn:${var.arn_format}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.lambda_function_name}:*"
+      "arn:${local.aws_partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.lambda_function_name}:*"
     ]
 
     actions = [
@@ -196,7 +196,7 @@ resource "aws_iam_role_policy" "geff_lambda_policy" {
 
 data "aws_iam_policy" "geff_lambda_vpc_policy" {
   count = var.deploy_lambda_in_vpc ? 1 : 0
-  arn   = "arn:${var.arn_format}:iam::aws:policy/service-role/AWSLambdaENIManagementAccess"
+  arn   = "arn:${local.aws_partition}:iam::aws:policy/service-role/AWSLambdaENIManagementAccess"
 }
 
 resource "aws_iam_policy_attachment" "geff_lambda_vpc_policy_attachment" {

--- a/kms.tf
+++ b/kms.tf
@@ -9,7 +9,7 @@ resource "aws_kms_key" "prod" {
           Action = "kms:*"
           Effect = "Allow"
           Principal = {
-            AWS = "arn:${var.arn_format}:iam::${local.account_id}:root"
+            AWS = "arn:${local.aws_partition}:iam::${local.account_id}:root"
           }
           Resource = "*"
           Sid      = "Enable IAM User Permissions"

--- a/storage_integration.tf
+++ b/storage_integration.tf
@@ -1,17 +1,18 @@
 module "storage_integration" {
-  source = "Snowflake-Labs/storage-integration-aws/snowflake"
+  source  = "Snowflake-Labs/storage-integration-aws/snowflake"
+  version = "0.2.11"
 
   # General
   prefix = var.prefix
   env    = var.env
 
   # AWS
-  arn_format                       = var.arn_format
   data_bucket_arns                 = var.data_bucket_arns
   snowflake_integration_user_roles = var.snowflake_integration_user_roles
 
   providers = {
     snowflake.storage_integration_role = snowflake.storage_integration_role
+    snowsql.storage_integration_role   = snowsql.storage_integration_role
     aws                                = aws
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -120,7 +120,7 @@ locals {
   lambda_image_repo_version = "${local.lambda_image_repo}:${var.geff_image_version}"
   lambda_function_name      = "${local.geff_prefix}-lambda"
 
-  geff_prefix                = "${var.prefix}-geff"
+  geff_prefix = "${var.prefix}-geff"
 
   inferred_api_gw_invoke_url = "https://${aws_api_gateway_rest_api.ef_to_lambda.id}.execute-api.${local.aws_region}.${local.aws_dns_suffix}/"
   api_gw_caller_role_name    = "${local.geff_prefix}-api-gateway-caller"

--- a/variables.tf
+++ b/variables.tf
@@ -88,12 +88,6 @@ variable "sentry_driver_dsn" {
   default     = ""
 }
 
-variable "arn_format" {
-  type        = string
-  description = "ARN format could be aws or aws-us-gov. Defaults to non-gov."
-  default     = "aws"
-}
-
 variable "create_dynamodb_table" {
   type        = bool
   description = "Boolean for if a DynamoDB table is to be created for batch locking."
@@ -117,25 +111,18 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  aws_region = data.aws_region.current.name
-}
+  account_id     = data.aws_caller_identity.current.account_id
+  aws_region     = data.aws_region.current.name
+  aws_partition  = data.aws_partition.current.partition
+  aws_dns_suffix = data.aws_partition.current.dns_suffix
 
-locals {
-  lambda_image_repo = "${local.account_id}.dkr.ecr.${local.aws_region}.amazonaws.com/geff"
-}
-
-locals {
+  lambda_image_repo         = "${local.account_id}.dkr.ecr.${local.aws_region}.${local.aws_dns_suffix}/geff"
   lambda_image_repo_version = "${local.lambda_image_repo}:${var.geff_image_version}"
-}
+  lambda_function_name      = "${local.geff_prefix}-lambda"
 
-locals {
-  inferred_api_gw_invoke_url = "https://${aws_api_gateway_rest_api.ef_to_lambda.id}.execute-api.${local.aws_region}.amazonaws.com/"
   geff_prefix                = "${var.prefix}-geff"
-}
 
-locals {
-  lambda_function_name    = "${local.geff_prefix}-lambda"
-  api_gw_caller_role_name = "${local.geff_prefix}-api-gateway-caller"
-  api_gw_logger_role_name = "${local.geff_prefix}-api-gateway-logger"
+  inferred_api_gw_invoke_url = "https://${aws_api_gateway_rest_api.ef_to_lambda.id}.execute-api.${local.aws_region}.${local.aws_dns_suffix}/"
+  api_gw_caller_role_name    = "${local.geff_prefix}-api-gateway-caller"
+  api_gw_logger_role_name    = "${local.geff_prefix}-api-gateway-logger"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,17 +4,27 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38.0"
+      version = ">= 5.72.0"
     }
 
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.64.0"
+      version = ">= 0.73.0"
 
       configuration_aliases = [
         snowflake.api_integration_role,
         snowflake.storage_integration_role,
       ]
     }
+
+    snowsql = {
+      source  = "aidanmelen/snowsql"
+      version = ">= 1.3.3"
+
+      configuration_aliases = [
+        snowsql.storage_integration_role,
+      ]
+    }
+
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -25,6 +25,5 @@ terraform {
         snowsql.storage_integration_role,
       ]
     }
-
   }
 }


### PR DESCRIPTION
Add support for sovereign cloud ARN format.  Also, use the snowsql Terraform provider if needed when the official Snowflake Terraform provider does not support storage integration on a specific sovereign cloud yet.